### PR TITLE
Allow baseurl replacement in the constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Axios service base for TypeScript
 
 A base class for API services using Axios.
+
+## Changelog
+
+### v0.2.0
+
+- ⚠️ The `ApiServiceBase` constructor now uses the `path` argument to fully replace the `baseUrl` value instead of just appending to it. It defaults to `/api`. This is to allow creating services for external APIs.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,47 @@
 
 A base class for API services using Axios.
 
+## Usage example
+
+Service declaration:
+
+```typescript
+import { Result } from 'rusty-result-ts'
+import { ApiError, ApiServiceBase } from 'axios-service-base-ts'
+
+export interface Person {
+  gender: 'female' | 'male'
+  name: {first: string, last: string}
+  email: string,
+}
+
+export class RandomPersonService extends ApiServiceBase {
+  constructor () {
+    super('https://randomuser.me/api')
+  }
+
+  public async getPerson (gender: 'female' | 'male'): Promise<Result<Person | null, ApiError>> {
+    return await this.get(`/?gender=${gender}`)
+  }
+}
+
+export const randomPersonService = new RandomPersonService()
+```
+
+Service usage:
+
+```typescript
+import { randomPersonService } from 'src/services/random-person-service'
+
+const result = await randomPersonService.getPerson('female')
+if (result.isOk() && result.value != null) {
+    const person = result.value
+    console.log(`A new person: ${person.name.first} ${person.name.last} - ${person.email}`)
+} else if (result.isErr()) {
+    console.log('Error:', result.error.errorMessage)
+}
+```
+
 ## Changelog
 
 ### v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "axios-service-base-ts",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.0",
+      "name": "axios-service-base-ts",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axios-service-base-ts",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A base class for API services using Axios",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/api-service-base.ts
+++ b/src/api-service-base.ts
@@ -9,10 +9,10 @@ export class ApiServiceBase {
 
   /**
    * Creates a new service instance.
-   * @param path A path appended to the `urlBase`.
+   * @param path A base path for all requests this service will make. Defaults to `/api`.
    */
-  public constructor (path = '') {
-    this.urlBase += path || ''
+  public constructor (path?: string) {
+    this.urlBase = path ?? '/api'
   }
 
   /**


### PR DESCRIPTION
⚠️ The `ApiServiceBase` constructor now uses the `path` argument to fully replace the `baseUrl` value instead of just appending to it. It defaults to `/api`. This is to allow creating services for external APIs.